### PR TITLE
Use custom ECR ASP.NET+NewRelic base image in Dockerfile

### DIFF
--- a/.github/workflows/aws_main-user.yml
+++ b/.github/workflows/aws_main-user.yml
@@ -57,7 +57,9 @@ jobs:
     # Build & Push da API
     - name: Build and push API image
       run: |
-        docker build -t ${{env.FCG_API_NAME}} -f ${{env.FCG_API_DOCKERFILE}} .
+        docker build --build-arg AWS_REGION=${{ vars.AWS_REGION }} \
+        --build-arg AWS_ACCOUNT_ID=${{ vars.AWS_ACCOUNT_ID }} \
+        -t ${{env.FCG_API_NAME}} -f ${{env.FCG_API_DOCKERFILE}} .
         docker tag ${{env.FCG_API_NAME}}:latest ${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/${{env.FCG_API_NAME}}:latest
         docker push ${{ vars.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/${{env.FCG_API_NAME}}:latest
 

--- a/FCG.User.API/Dockerfile
+++ b/FCG.User.API/Dockerfile
@@ -1,31 +1,7 @@
 ﻿# See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
-
-# This stage is used when running from VS in fast mode (Default for Debug configuration)
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
-USER $APP_UID
-WORKDIR /app
-EXPOSE 8080
-EXPOSE 8081
-
-# Enable the agent
-ENV CORECLR_ENABLE_PROFILING=1 \
-CORECLR_PROFILER={36032161-FFC0-4B61-B559-F6C5D41BAE5A} \
-CORECLR_NEWRELIC_HOME=/usr/local/newrelic-dotnet-agent \
-CORECLR_PROFILER_PATH=/usr/local/newrelic-dotnet-agent/libNewRelicProfiler.so \
-NEW_RELIC_LICENSE_KEY=49fea977ae8cb8915399b2c027e24687FFFFNRAL \
-NEW_RELIC_APP_NAME="fcg-user-api"
-
-# ✅ Troca para root para conseguir instalar pacotes
-USER root
-
-RUN apt-get update && \
-    apt-get install -y wget ca-certificates gnupg && \
-    mkdir -p /usr/share/keyrings && \
-    wget -O- https://download.newrelic.com/548C16BF.gpg | gpg --dearmor -o /usr/share/keyrings/newrelic-archive-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/newrelic-archive-keyring.gpg] http://apt.newrelic.com/debian/ newrelic non-free" > /etc/apt/sources.list.d/newrelic.list && \
-    apt-get update && \
-    apt-get install -y newrelic-dotnet-agent && \
-    rm -rf /var/lib/apt/lists/*
+ARG AWS_ACCOUNT_ID
+ARG AWS_REGION
+ARG BASE_RUNTIME_IMAGE=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/aspnet-newrelic-runtime:latest
 
 # This stage is used to build the service project
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
@@ -45,8 +21,9 @@ FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
 RUN dotnet publish "./FCG.User.API.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
-# This stage is used in production or when running from VS in regular mode (Default when not using the Debug configuration)
-FROM base AS final
+
+# Stage final: usa a imagem do ECR com aspnet + new relic
+FROM ${BASE_RUNTIME_IMAGE} AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "FCG.User.API.dll"]

--- a/k8s/users-api-config.yaml
+++ b/k8s/users-api-config.yaml
@@ -6,3 +6,4 @@ data:
   API__GamesApiBaseUrl: "https://fcg-game-api.whitesea-88353420.westus2.azurecontainerapps.io"
   API__UsersApiBaseUrl: "https://fcg-user-api.whitesea-88353420.westus2.azurecontainerapps.io"
   API__PaymentGatewayBaseUrl: "https://payment-gateway-hjgsdacahzdmazdc.canadacentral-01.azurewebsites.net"
+  NEW_RELIC_APP_NAME: "fcg-users-api"


### PR DESCRIPTION
Use custom ECR ASP.NET+NewRelic base image in Dockerfile

Refactored Dockerfile to use a private ASP.NET + New Relic runtime image from AWS ECR, replacing the public Microsoft base image and in-Dockerfile agent installation. Updated GitHub Actions workflow to pass AWS region/account as build args for image resolution. Added NEW_RELIC_APP_NAME to users-api-config.yaml for improved New Relic configuration.

#### PR Classification
Infrastructure update to use a custom runtime image and improve observability configuration.

#### PR Summary
This PR updates the Dockerfile and CI workflow to use a custom ASP.NET + New Relic base image from AWS ECR, and enhances New Relic monitoring configuration.
- Dockerfile: Switched to a custom ECR base image with New Relic, removed inline agent installation, and added build arguments for AWS integration.
- aws_main-user.yml: Modified Docker build step to pass AWS_REGION and AWS_ACCOUNT_ID as build arguments.
- users-api-config.yaml: Added NEW_RELIC_APP_NAME environment variable for improved monitoring.
